### PR TITLE
Fix AsymFlow VRAM predictor for pixel-space input

### DIFF
--- a/modules/model_base.py
+++ b/modules/model_base.py
@@ -224,14 +224,3 @@ class AsymFlux2(_Flux2):
     def __init__(self, model_config, device=None):
         _Flux.__init__(self, model_config, device=device, unet_model=architectures.AsymFlux)
         self.memory_usage_factor_conds = ("ref_latents",)
-
-    def memory_required(self, input_shape, cond_shapes={}):
-        # Pixel-space input -> rebase to /8 latent for Flux2's predictor.
-        def r(s):
-            s = list(s)
-            if len(s) >= 4:
-                s[-2] //= 8
-                s[-1] //= 8
-            return tuple(s)
-        cs = {k: [r(s) for s in v] for k, v in cond_shapes.items()}
-        return super().memory_required(r(input_shape), cs)

--- a/modules/model_base.py
+++ b/modules/model_base.py
@@ -224,3 +224,14 @@ class AsymFlux2(_Flux2):
     def __init__(self, model_config, device=None):
         _Flux.__init__(self, model_config, device=device, unet_model=architectures.AsymFlux)
         self.memory_usage_factor_conds = ("ref_latents",)
+
+    def memory_required(self, input_shape, cond_shapes={}):
+        # Pixel-space input -> rebase to /8 latent for Flux2's predictor.
+        def r(s):
+            s = list(s)
+            if len(s) >= 4:
+                s[-2] //= 8
+                s[-1] //= 8
+            return tuple(s)
+        cs = {k: [r(s) for s in v] for k, v in cond_shapes.items()}
+        return super().memory_required(r(input_shape), cs)

--- a/modules/supported_models.py
+++ b/modules/supported_models.py
@@ -149,12 +149,16 @@ class GMFlux2(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = latent_formats.Flux2
 
-    memory_usage_factor = 3.1 * (2.0 * 2.0) * 2.36
+    memory_usage_factor = 3.1
 
     supported_inference_dtypes = [torch.bfloat16, torch.float16, torch.float32]
 
     vae_key_prefix = ["vae."]
     text_encoder_key_prefix = ["text_encoders."]
+
+    def __init__(self, unet_config):
+        super().__init__(unet_config)
+        self.memory_usage_factor = self.memory_usage_factor * (2.0 * 2.0) * (unet_config["hidden_size"] / 2604)
 
     def get_model(self, state_dict, prefix="", device=None):
         out = model_base.GMFlux2(self, device=device)
@@ -179,12 +183,16 @@ class Flux2(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = latent_formats.Flux2
 
-    memory_usage_factor = 3.1 * (2.0 * 2.0) * 2.36
+    memory_usage_factor = 3.1
 
     supported_inference_dtypes = [torch.bfloat16, torch.float16, torch.float32]
 
     vae_key_prefix = ["vae."]
     text_encoder_key_prefix = ["text_encoders."]
+
+    def __init__(self, unet_config):
+        super().__init__(unet_config)
+        self.memory_usage_factor = self.memory_usage_factor * (2.0 * 2.0) * (unet_config['hidden_size'] / 2604)
 
     def get_model(self, state_dict, prefix="", device=None):
         out = model_base.Flux2(self, device=device)
@@ -206,12 +214,18 @@ class AsymFlux2(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = OklabPixels
 
-    memory_usage_factor = 3.1 * (2.0 * 2.0) * 2.36
+    memory_usage_factor = 3.1
 
     supported_inference_dtypes = [torch.bfloat16, torch.float16, torch.float32]
 
     vae_key_prefix = ["vae."]
     text_encoder_key_prefix = ["text_encoders."]
+
+    def __init__(self, unet_config):
+        super().__init__(unet_config)
+        hidden_size = unet_config["hidden_size"]
+        patch_size = unet_config["patch_size"]
+        self.memory_usage_factor = self.memory_usage_factor * (2.0 * 2.0) * (hidden_size / 2604) / (patch_size * patch_size)
 
     def get_model(self, state_dict, prefix="", device=None):
         out = model_base.AsymFlux2(self, device=device)

--- a/modules/supported_models.py
+++ b/modules/supported_models.py
@@ -206,7 +206,7 @@ class AsymFlux2(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = OklabPixels
 
-    memory_usage_factor = 3.1 * 2.36
+    memory_usage_factor = 3.1 * (2.0 * 2.0) * 2.36
 
     supported_inference_dtypes = [torch.bfloat16, torch.float16, torch.float32]
 


### PR DESCRIPTION
# Fix AsymFlow VRAM over-prediction causing full-offload on cards with plenty of VRAM

## Problem

On any card that should comfortably fit AsymFlow (e.g. RTX 5090 32 GB
loading the ~9 GB FLUX.2-klein fp8 base + adapter), ComfyUI dumps the
entire model to CPU and pages weights over PCIe per step:

```
loaded partially; 0.00 MB usable, 0.00 MB loaded, 9134.01 MB offloaded,
768.00 MB buffer reserved, lowvram patches: 58
```

The same workflow runs at full GPU speed when launched with `--highvram`
(which bypasses the predictor), so the model fits — comfy's predictor
is just wrong about how much it needs.

## Root cause

`AsymFlux2` inherits its activation-memory predictor from `Flux2`.
ComfyUI's predictor (`comfy/model_base.py` `memory_required`) is roughly:

```
needed_MB ≈ batch × H × W × dtype.itemsize × 0.01 × memory_usage_factor
```

where `H × W` is the **input** spatial size. The `Flux2`-style
`memory_usage_factor` is calibrated assuming the input is a **/8
latent**. AsymFlux2 instead receives **full-resolution pixel-space
input** (1:1, 3 channels) — the `OklabPixels` latent format sets
`spacial_downscale_ratio = 1`.

At the same image resolution (e.g. 1024×1024), AsymFlux2 sees 64× the
area Flux2 sees. With the previous `memory_usage_factor = 3.1 * 2.36`
(which also dropped Flux2's `(2.0 * 2.0)` patch² term, so the factor
was actually *understated* relative to Flux2, but only by 4×, not 64×),
the predictor reports ≈ 150 GB needed at 1024×1024 bf16. Comfy decides
nothing fits, sets "0 MB usable", and offloads everything.

Note that the **attention token count** is actually identical between
the two at the same image res: Flux2 with patch=2 on a /8 latent →
`(R/16)²` tokens; AsymFlux2 with patch=16 on the full image →
`(R/16)²` tokens. So real VRAM cost should match Flux2 at the same
image res — the predictor just needs to see the equivalent shape.

## Fix

Two-line change:

1. **`modules/supported_models.py`** — set `AsymFlux2.memory_usage_factor`
   to the same value as `Flux2` (`3.1 * (2.0 * 2.0) * 2.36`). The
   underlying transformer is structurally identical; only the I/O wiring
   differs.

2. **`modules/model_base.py`** — override `AsymFlux2.memory_required` to
   rebase the input/cond shapes from pixel coordinates to /8
   latent-equivalent before delegating to the parent predictor. This
   makes the inherited Flux2 calibration produce the right number.

```python
def memory_required(self, input_shape, cond_shapes={}):
    # Pixel-space input -> rebase to /8 latent for Flux2's predictor.
    def r(s):
        s = list(s)
        if len(s) >= 4:
            s[-2] //= 8
            s[-1] //= 8
        return tuple(s)
    cs = {k: [r(s) for s in v] for k, v in cond_shapes.items()}
    return super().memory_required(r(input_shape), cs)
```

The `len(s) >= 4` guard skips non-image cond shapes (text/clip
embeddings come in as 2D/3D).

## Reproduction

- Card: RTX 5090 (32 GB), no flags
- Workflow: `Load AsymFlow Model` (or `Load AsymFlow Model (GGUF)` with
  Q8 GGUF base) + AsymFLUX.2-klein adapter, 1024×1024
- Before: `loaded partially; 0.00 MB loaded, 9134 MB offloaded`,
  ~1.5 s/it
- After: `loaded completely; 9134 MB loaded, 0 MB offloaded`,
  ~1.5 it/s (≈ 2.25× speedup, the actual PCIe-paging cost)

## Risk

Low. The change only affects the predictor, not the model itself:

- If the prediction is slightly *under*-aggressive, comfy may try to
  load more than will fit at extreme resolutions, falling back to OOM
  the same way Flux2 itself would.
- If it's slightly *over*-aggressive, behavior degrades to the current
  state (offloading), which is the worst case anyway.

The override matches Flux2's behavior at the equivalent image
resolution, which is already exercised across the codebase.
