### PR TITLE
Fix 4x under-prediction in AsymFlow VRAM memory factor

### DIFF
--- a/modules/supported_models.py
+++ b/modules/supported_models.py
@@ -225,7 +225,7 @@ class AsymFlux2(supported_models_base.BASE):
         super().__init__(unet_config)
         hidden_size = unet_config["hidden_size"]
         patch_size = unet_config["patch_size"]
-        self.memory_usage_factor = self.memory_usage_factor * (2.0 * 2.0) * (hidden_size / 2604) / (patch_size * patch_size)
+        self.memory_usage_factor = self.memory_usage_factor * (2.0 * 2.0) * (hidden_size / 2604) / ((patch_size // 2) ** 2)
 
     def get_model(self, state_dict, prefix="", device=None):
         out = model_base.AsymFlux2(self, device=device)


### PR DESCRIPTION
Follow-up to #32.

The cleanup in #32 was the cleaner direction: folding the pixel-space
shape adjustment into `memory_usage_factor` avoids a custom
`memory_required()` override and keeps the model config logic simpler.

This follow-up adjusts the scale of that factor.

## Issue

The cleanup used the pure pixel-patch area correction:

```python
/ (patch_size * patch_size)
```

For AsymFlux2 with `patch_size=16`, that divides the estimate by 256.
In practice this under-predicts the memory ComfyUI needs to reserve for
sampling headroom.

ComfyUI uses `memory_usage_factor` not only as a display estimate, but
also as part of its model loading/offloading decisions. With the lower
estimate, ComfyUI can keep more model memory resident than needed, which
increased observed peak VRAM on my setup.

Observed at `1024x1440` on a 32 GB card:

| Version | Peak VRAM |
|---|---:|
| Original `/8` rebase fix | ~14 GB |
| Cleanup factor-only fix | ~24 GB |

## Fix

Use the same effective correction as the original `/8` rebase fix, but
keep it in the cleaner factor-only form:

```python
/ ((patch_size // 2) ** 2)
```

For the current AsymFlux2 `patch_size=16`, this divides by 64 instead of
256, restoring the conservative headroom while preserving the simplified
implementation from #32.
